### PR TITLE
feat: add s2i v2alpha1 unit test

### DIFF
--- a/pkg/kapis/s2i/v2apha1/handler.go
+++ b/pkg/kapis/s2i/v2apha1/handler.go
@@ -2,6 +2,7 @@ package v2alpha1
 
 import (
 	"context"
+
 	"github.com/emicklei/go-restful"
 	"github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -32,24 +33,22 @@ func newAPIHandler(o apiHandlerOption) *apiHandler {
 
 func (h *apiHandler) listImageBuilds(request *restful.Request, response *restful.Response) {
 	nsName := request.PathParameter("namespace")
-	//buildName := request.PathParameter("imageBuild")
-
 	queryParam := query.ParseQueryParameter(request)
-
-	//labelSelector := labels.SelectorFromSet(labels.Set{"build.shipwright.io/name": buildName})
 
 	opts := make([]client.ListOption, 0, 3)
 	opts = append(opts, client.InNamespace(nsName))
-	//opts = append(opts, client.MatchingLabelsSelector{Selector: labelSelector})
-
 	buildList := &v1alpha1.BuildList{}
-	// fetch PipelineRuns
+
 	if err := h.client.List(context.Background(), buildList, opts...); err != nil {
 		kapis.HandleError(request, response, err)
 		return
 	}
 
-	apiResult := resourcesV1alpha3.DefaultList(toBuildObjects(buildList.Items), queryParam, resourcesV1alpha3.DefaultCompare(), resourcesV1alpha3.DefaultFilter(), nil)
+	apiResult := resourcesV1alpha3.DefaultList(
+		toBuildObjects(buildList.Items),
+		queryParam,
+		resourcesV1alpha3.DefaultCompare(),
+		resourcesV1alpha3.DefaultFilter(), nil)
 
 	_ = response.WriteAsJson(apiResult)
 }
@@ -98,7 +97,6 @@ func (h *apiHandler) updateImageBuild(request *restful.Request, response *restfu
 	nsName := request.PathParameter("namespace")
 	imageBuildName := request.PathParameter("imageBuild")
 
-	//获取旧build
 	oldBuild := v1alpha1.Build{}
 	if err := h.client.Get(context.Background(), client.ObjectKey{Name: imageBuildName}, &oldBuild); err != nil {
 		kapis.HandleError(request, response, err)
@@ -116,12 +114,10 @@ func (h *apiHandler) updateImageBuild(request *restful.Request, response *restfu
 		return
 	}
 
-	//oldBuild.Name = imageBuildName + "-"
 	oldBuild.Spec.Source.URL = &codeUrl
 	if "nodejs" == languageKind {
 		oldBuild.Spec.Strategy.Name = "buildpacks-v3"
 	}
-	//build.Spec.Strategy.Name = "buildpacks-v3"
 	oldBuild.Spec.Output.Image = outputImageUrl
 	oldBuild.Namespace = nsName
 
@@ -188,6 +184,19 @@ func (h *apiHandler) createImageBuildRun(request *restful.Request, response *res
 	_ = response.WriteEntity(buildRun)
 }
 
+func (h *apiHandler) getImageBuildRun(request *restful.Request, response *restful.Response) {
+	nsName := request.PathParameter("namespace")
+	imageBuildRunName := request.PathParameter("ImageBuildRun")
+
+	// get imageBuildRun
+	buildRun := v1alpha1.BuildRun{}
+	if err := h.client.Get(context.Background(), client.ObjectKey{Namespace: nsName, Name: imageBuildRunName}, &buildRun); err != nil {
+		kapis.HandleError(request, response, err)
+		return
+	}
+	_ = response.WriteEntity(&buildRun)
+}
+
 func (h *apiHandler) deleteImageBuildRun(request *restful.Request, response *restful.Response) {
 	nsName := request.PathParameter("namespace")
 	imageBuildRunName := request.PathParameter("ImageBuildRun")
@@ -205,22 +214,6 @@ func (h *apiHandler) deleteImageBuildRun(request *restful.Request, response *res
 	}
 	_ = response.WriteEntity(&buildRun)
 }
-
-//func (h *handler) deleteGitRepositories(req *restful.Request, res *restful.Response) {
-//	namespace := common.GetPathParameter(req, common.NamespacePathParameter)
-//	repoName := common.GetPathParameter(req, pathParameterGitRepository)
-//	ctx := context.Background()
-//
-//	repo := &v1alpha3.GitRepository{}
-//	err := h.Get(ctx, types.NamespacedName{
-//		Namespace: namespace,
-//		Name:      repoName,
-//	}, repo)
-//	if err == nil {
-//		err = h.Delete(ctx, repo)
-//	}
-//	common.Response(req, res, repo, err)
-//}
 
 func (h *apiHandler) listImageBuildRuns(request *restful.Request, response *restful.Response) {
 	nsName := request.PathParameter("namespace")
@@ -240,7 +233,10 @@ func (h *apiHandler) listImageBuildRuns(request *restful.Request, response *rest
 		return
 	}
 
-	apiResult := resourcesV1alpha3.DefaultList(toBuildRunObjects(buildRunList.Items), queryParam, resourcesV1alpha3.DefaultCompare(), resourcesV1alpha3.DefaultFilter(), nil)
+	apiResult := resourcesV1alpha3.DefaultList(toBuildRunObjects(buildRunList.Items),
+		queryParam,
+		resourcesV1alpha3.DefaultCompare(),
+		resourcesV1alpha3.DefaultFilter(), nil)
 
 	_ = response.WriteAsJson(apiResult)
 }
@@ -257,34 +253,34 @@ func (h *apiHandler) getImageBuildStrategy(request *restful.Request, response *r
 	nsName := request.PathParameter("namespace")
 	imageBuildStrategyName := request.PathParameter("imageBuildStrategy")
 
-	// get imageBuild
-	Strategy := v1alpha1.BuildStrategy{}
+	// get imageBuildStrategy
+	strategy := v1alpha1.BuildStrategy{}
 	if err := h.client.Get(context.Background(), client.ObjectKey{Namespace: nsName, Name: imageBuildStrategyName}, &Strategy); err != nil {
 		kapis.HandleError(request, response, err)
 		return
 	}
-	_ = response.WriteEntity(&Strategy)
+	_ = response.WriteEntity(&strategy)
 }
 
-func (h *apiHandler) listImageBuildStrategy(request *restful.Request, response *restful.Response) {
+func (h *apiHandler) listImageBuildStrategies(request *restful.Request, response *restful.Response) {
 	nsName := request.PathParameter("namespace")
 
 	queryParam := query.ParseQueryParameter(request)
 
-	//labelSelector := labels.SelectorFromSet(labels.Set{"build.shipwright.io/name": buildName})
-
 	opts := make([]client.ListOption, 0, 3)
 	opts = append(opts, client.InNamespace(nsName))
-	//opts = append(opts, client.MatchingLabelsSelector{Selector: labelSelector})
 
 	buildStrategyList := &v1alpha1.BuildStrategyList{}
-	// fetch PipelineRuns
+
 	if err := h.client.List(context.Background(), buildStrategyList, opts...); err != nil {
 		kapis.HandleError(request, response, err)
 		return
 	}
 
-	apiResult := resourcesV1alpha3.DefaultList(toBuildStrategyObjects(buildStrategyList.Items), queryParam, resourcesV1alpha3.DefaultCompare(), resourcesV1alpha3.DefaultFilter(), nil)
+	apiResult := resourcesV1alpha3.DefaultList(toBuildStrategyObjects(buildStrategyList.Items),
+		queryParam,
+		resourcesV1alpha3.DefaultCompare(),
+		resourcesV1alpha3.DefaultFilter(), nil)
 
 	_ = response.WriteAsJson(apiResult)
 }

--- a/pkg/kapis/s2i/v2apha1/handler_test.go
+++ b/pkg/kapis/s2i/v2apha1/handler_test.go
@@ -1,0 +1,21 @@
+/*
+
+  Copyright 2020 The KubeSphere Authors.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+*/
+
+package v2alpha1
+
+// TODO: 

--- a/pkg/kapis/s2i/v2apha1/register.go
+++ b/pkg/kapis/s2i/v2apha1/register.go
@@ -19,11 +19,12 @@
 package v2alpha1
 
 import (
+	"net/http"
+
 	"github.com/emicklei/go-restful"
 	"github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
 	"kubesphere.io/devops/pkg/api"
 	devopsClient "kubesphere.io/devops/pkg/client/devops"
-	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -34,76 +35,85 @@ func RegisterRoutes(ws *restful.WebService, devopsClient devopsClient.Interface,
 		client:       c,
 	})
 
-	//ws.Route(ws.GET("/namespaces/{namespace}/imageBuilds/{imageBuild}").
-	ws.Route(ws.GET("/namespaces/{namespace}/imageBuilds").
-		To(handler.listImageBuilds).
-		Doc("Get all imageBuilds").
-		Param(ws.PathParameter("namespace", "Namespace of the imageBuild")).
-		//Param(ws.PathParameter("imageBuild", "Name of the imageBuild")).
-		Returns(http.StatusOK, api.StatusOK, v1alpha1.BuildList{}))
-
 	ws.Route(ws.POST("/namespaces/{namespace}/ImageBuilds/{ImageBuild}").
 		To(handler.createImageBuild).
-		Doc("Create a ImageBuild").
+		Doc("Create an ImageBuild").
 		Param(ws.PathParameter("namespace", "Namespace of the ImageBuild")).
-		Param(ws.PathParameter("ImageBuild", "Name of the ImageBuild")).
+		Param(ws.PathParameter("imageBuild", "Name of the ImageBuild")).
 		Param(ws.QueryParameter("codeUrl", "URL for the code")).
 		Param(ws.QueryParameter("languageKind", "Kind of the language")).
 		Param(ws.QueryParameter("outputImageUrl", "Output image url")).
-		//Param(ws.QueryParameter("branch", "The name of SCM reference, only for multi-branch pipeline")).
 		Returns(http.StatusCreated, api.StatusOK, v1alpha1.Build{}))
+
+	ws.Route(ws.GET("/namespaces/{namespace}/imageBuilds").
+		To(handler.listImageBuilds).
+		Doc("Get all imageBuilds").
+		Param(ws.PathParameter("namespace", "Namespace of the imageBuilds")).
+		Returns(http.StatusOK, api.StatusOK, v1alpha1.BuildList{}))
 
 	ws.Route(ws.GET("/namespaces/{namespace}/ImageBuilds/{ImageBuild}").
 		To(handler.getImageBuild).
-		Doc("Get a ImageBuild").
+		Doc("Get an ImageBuild").
 		Param(ws.PathParameter("namespace", "Namespace of the ImageBuild")).
-		Param(ws.PathParameter("ImageBuild", "Name of the ImageBuild")).
+		Param(ws.PathParameter("imageBuild", "Name of the ImageBuild")).
 		Returns(http.StatusOK, api.StatusOK, v1alpha1.Build{}))
 
 	ws.Route(ws.GET("/namespaces/{namespace}/ImageBuilds/{ImageBuild}").
 		To(handler.deleteImageBuild).
-		Doc("Get a ImageBuild").
-		Param(ws.PathParameter("namespace", "Namespace of the ImageBuild")).
-		Param(ws.PathParameter("ImageBuild", "Name of the ImageBuild")).
-		Returns(http.StatusOK, api.StatusOK, v1alpha1.Build{}))
-
-	ws.Route(ws.POST("/namespaces/{namespace}/ImageBuildRuns/{ImageBuildRun}").
-		To(handler.createImageBuildRun).
-		Doc("Create a ImageBuildRun").
+		Doc("Delete an ImageBuild").
 		Param(ws.PathParameter("namespace", "Namespace of the ImageBuildRun")).
-		Param(ws.PathParameter("ImageBuildRun", "Name of the ImageBuildRun for imageBuild")).
-		Param(ws.QueryParameter("ImageBuild", "Name of Build for the buildRun")).
-		//Param(ws.QueryParameter("branch", "The name of SCM reference, only for multi-branch pipeline")).
+		Param(ws.PathParameter("imageBuild", "Name of the ImageBuildRun")).
+		Returns(http.StatusOK, api.StatusOK, v1alpha1.BuildRun{}))
+
+	ws.Route(ws.POST("/namespaces/{namespace}/ImageBuilds/{ImageBuild}").
+		To(handler.updateImageBuild).
+		Doc("Update an ImageBuild").
+		Param(ws.PathParameter("namespace", "Namespace of the ImageBuild")).
+		Param(ws.PathParameter("imageBuild", "Name of the ImageBuild")).
+		Param(ws.QueryParameter("codeUrl", "URL for the code")).
+		Param(ws.QueryParameter("languageKind", "Kind of the language")).
+		Param(ws.QueryParameter("outputImageUrl", "Output image url")).
 		Returns(http.StatusCreated, api.StatusOK, v1alpha1.Build{}))
 
-	ws.Route(ws.GET("/namespaces/{namespace}/ImageBuildRuns/{ImageBuildRun}").
-		To(handler.deleteImageBuildRun).
-		Doc("Delete a ImageBuildRun").
-		Param(ws.PathParameter("namespace", "Namespace of the ImageBuildRun")).
-		Param(ws.PathParameter("ImageBuildRun", "Name of the ImageBuildRun")).
-		Returns(http.StatusOK, api.StatusOK, v1alpha1.Build{}))
-
-	ws.Route(ws.GET("/namespaces/{namespace}/ImageBuildRuns/{ImageBuild}").
-		To(handler.listImageBuildRuns).
-		Doc("Create a ImageBuildRun").
-		Param(ws.PathParameter("namespace", "Namespace of the ImageBuildRun")).
-		//Param(ws.PathParameter("ImageBuildRun", "Name of the ImageBuildRun for imageBuild")).
-		Param(ws.QueryParameter("ImageBuild", "Name of Build for the buildRun")).
-		//Param(ws.QueryParameter("branch", "The name of SCM reference, only for multi-branch pipeline")).
-		Returns(http.StatusCreated, api.StatusOK, v1alpha1.BuildRunList{}))
+	ws.Route(ws.GET("/namespaces/{namespace}/ImageBuildStrategies").
+		To(handler.listImageBuildStrategies).
+		Doc("Get all ImageBuildStrategies").
+		Param(ws.PathParameter("namespace", "Namespace of the ImageBuildStrategies")).
+		Returns(http.StatusOK, api.StatusOK, v1alpha1.BuildStrategyList{}))
 
 	ws.Route(ws.GET("/namespaces/{namespace}/imageBuildStrategys/{imageBuildStrategy}").
 		To(handler.getImageBuildStrategy).
-		Doc("Get a imageBuildStrategy").
+		Doc("Get an imageBuildStrategy").
 		Param(ws.PathParameter("namespace", "Namespace of the imageBuildStrategy")).
-		Param(ws.PathParameter("getImageBuildStrategy", "Name of the imageBuildStrategy")).
+		Param(ws.PathParameter("imageBuildStrategy", "Name of the imageBuildStrategy")).
 		Returns(http.StatusOK, api.StatusOK, v1alpha1.BuildStrategy{}))
 
-	ws.Route(ws.GET("/namespaces/{namespace}/ImageBuildStrategys").
-		To(handler.listImageBuildStrategy).
-		Doc("Get all ImageBuildStrategy").
-		Param(ws.PathParameter("namespace", "Namespace of the ImageBuildStrategy")).
-		//Param(ws.PathParameter("imageBuild", "Name of the imageBuild")).
-		Returns(http.StatusOK, api.StatusOK, v1alpha1.BuildList{}))
+	ws.Route(ws.POST("/namespaces/{namespace}/ImageBuildRuns/{ImageBuildRun}").
+		To(handler.createImageBuildRun).
+		Doc("Create an ImageBuildRun").
+		Param(ws.PathParameter("namespace", "Namespace of the ImageBuildRun")).
+		Param(ws.PathParameter("imageBuildRun", "Name of the ImageBuildRun for imageBuild")).
+		Param(ws.QueryParameter("imageBuild", "Name of Build for the buildRun")).
+		Returns(http.StatusCreated, api.StatusOK, v1alpha1.BuildRun{}))
+
+	ws.Route(ws.GET("/namespace/{namespace}/ImageBuildRuns").
+		To(handler.listImageBuildRuns).
+		Doc("Get all imageBuildRuns").
+		Param(ws.PathParameter("namespace", "Namespace of imageBuildRuns")).
+		Returns(http.StatusOK, api.StatusOK, v1alpha1.BuildRunList{}))
+
+	ws.Route(ws.GET("/namespace/{namespace}/ImageBuildRuns/{ImageBuildRun}").
+		To(handler.getImageBuildRun).
+		Doc("Get an imageBuildRun").
+		Param(ws.PathParameter("namespace", "Namespace of imageBuildRun")).
+		Param(ws.PathParameter("imageBuildRun", "Name of the ImageBuildRun")).
+		Returns(http.StatusOK, api.StatusOK, v1alpha1.BuildRun{}))
+
+	ws.Route(ws.GET("/namespaces/{namespace}/ImageBuildRuns/{ImageBuildRun}").
+		To(handler.deleteImageBuildRun).
+		Doc("Delete an ImageBuildRun").
+		Param(ws.PathParameter("namespace", "Namespace of the ImageBuildRun")).
+		Param(ws.PathParameter("imageBuildRun", "Name of the ImageBuildRun")).
+		Returns(http.StatusOK, api.StatusOK, v1alpha1.BuildRun{}))
 
 }

--- a/pkg/kapis/s2i/v2apha1/register_test.go
+++ b/pkg/kapis/s2i/v2apha1/register_test.go
@@ -1,0 +1,127 @@
+/*
+
+  Copyright 2020 The KubeSphere Authors.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+*/
+
+package v2alpha1
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/emicklei/go-restful"
+	"github.com/stretchr/testify/assert"
+	"kubesphere.io/devops/pkg/api/devops/v1alpha1"
+	"kubesphere.io/devops/pkg/api/devops/v2alpha1"
+	"kubesphere.io/devops/pkg/apiserver/runtime"
+	fakedevops "kubesphere.io/devops/pkg/client/devops/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestAPIsExist(t *testing.T) {
+	httpWriter := httptest.NewRecorder()
+	wsWithGroup := runtime.NewWebService(v2alpha1.GroupVersion)
+
+	schema, err := v1alpha1.SchemeBuilder.Register().Build()
+	assert.Nil(t, err)
+
+	RegisterRoutes(wsWithGroup, fakedevops.NewFakeDevops(nil), fake.NewFakeClientWithScheme(schema))
+	restful.DefaultContainer.Add(wsWithGroup)
+
+	type args struct {
+		method string
+		uri    string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{{
+		name: "create an imageBuild",
+		args: args{
+			method: http.MethodPost,
+			uri:    "/namespaces/fake/ImageBuilds/fake",
+		},
+	}, {
+		name: "get all imageBuilds",
+		args: args{
+			method: http.MethodGet,
+			uri:    "/namespaces/fake/ImageBuilds",
+		},
+	}, {
+		name: "get an imageBuild",
+		args: args{
+			method: http.MethodGet,
+			uri:    "/namespaces/fake/ImageBuilds/fake",
+		},
+	}, {
+		name: "delete an imageBuild",
+		args: args{
+			method: http.MethodPost,
+			uri:    "/namespaces/fake/ImageBuilds/fake",
+		},
+	}, {
+		name: "update an imageBuild",
+		args: args{
+			method: http.MethodPost,
+			uri:    "/namespaces/fake/ImageBuilds/fake",
+		},
+	}, {
+		name: "get all imageBuildStrategies",
+		args: args{
+			method: http.MethodGet,
+			uri:    "/namespaces/fake/ImageBuildStrategies",
+		},
+	}, {
+		name: "get an imageBuildStrategy",
+		args: args{
+			method: http.MethodGet,
+			uri:    "/namespaces/fake/imageBuildStrategies/fake",
+		},
+	}, {
+		name: "create an imageBuildRun",
+		args: args{
+			method: http.MethodPost,
+			uri:    "/namespaces/fake/ImageBuildRuns/fake",
+		},
+	}, {
+		name: "get all imageBuildRun",
+		args: args{
+			method: http.MethodGet,
+			uri:    "/namespaces/fake/ImageBuildRuns",
+		},
+	}, {
+		name: "get an imageBuildRun",
+		args: args{
+			method: http.MethodGet,
+			uri:    "/namespace/fake/ImageBuildRuns/fake",
+		},
+	}, {
+		name: "delete an imageBuildRun",
+		args: args{
+			method: http.MethodGet,
+			uri:    "/namespaces/fake/ImageBuildRuns/fake",
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			httpRequest, _ := http.NewRequest(tt.args.method,
+				"http://fake.com/kapis/devops.kubesphere.io/v2alpha1"+tt.args.uri, nil)
+			restful.DefaultContainer.Dispatch(httpWriter, httpRequest)
+			assert.NotEqual(t, httpWriter.Code, 404)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by the KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
4. Additional open-source best practice: https://github.com/LinuxSuRen/open-source-best-practice
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind chore

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Please leave it or change # to be None if there is no corresponding issue that exists
-->
Fixes #

### Special notes for reviewers:
<!--
You can use the following command to let the DevOps SIG members help you to review your PR.
/cc @kubesphere/sig-devops 
And please avoid cc any individual.
-->
Please check the following list before waiting reviewers:

- [ ] Already committed the CRD files to [the Helm Chart](https://github.com/kubesphere-sigs/ks-devops-helm-chart/) if you created some new CRDs
- [ ] Already [added the permission](https://github.com/kubesphere/ks-installer/blob/9e063b085a0e43fdb3d0d9e3e7f4149146f14b9c/roles/ks-core/prepare/files/ks-init/role-templates.yaml) for the new API
- [ ] Already added the RBAC markers for the new controllers

### Does this PR introduce a user-facing change??
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

Please keep the note be same as your PR title if you believe it should be in the release notes.
-->
```release-note

```
